### PR TITLE
Fix a compatible issue in .NET Core

### DIFF
--- a/src/System.Numerics.MPFR/ModuleInitializer.cs
+++ b/src/System.Numerics.MPFR/ModuleInitializer.cs
@@ -165,6 +165,7 @@ public static class ModuleInitializer
 				WorkingDirectory = AssemblyLocation,
 				Arguments = "x mpfr_gmp.7z",
 				WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden,
+				UseShellExecute = true, 
 			};
 			var proc = Process.Start(info);
 			proc.WaitForExit();


### PR DESCRIPTION
There was a breaking change in .NET Core - they changed the default for UseShellExecute from true to false.

Without UseShellExecute, it will work reliably only in .NET Framework. In .NET Core, it will fail unless the 7zdec.exe file happens to be in the current directory.